### PR TITLE
ref: Cleanup SAML setup configuration form styles

### DIFF
--- a/sentry_auth_saml2/templates/sentry_auth_saml2/select-idp.html
+++ b/sentry_auth_saml2/templates/sentry_auth_saml2/select-idp.html
@@ -1,84 +1,105 @@
-{% extends "sentry/bases/auth.html" %}
+{% extends "sentry/bases/modal.html" %}
+{% load sentry_assets %}
+{% load i18n %}
 
-{% block auth_main %}
-  <div class="box">
-    <div class="box-content with-padding">
-      <h3>Register IdP data</h3>
+{% block wrapperclass %}narrow auth{% endblock %}
+{% block modal_header_signout %}{% endblock %}
 
-      <div class="help-block">Contact the IdP administrator and ask him for the IdP metadata and its public x509 certificate. You can:</div>
+{% block title %}{% trans "Register Identity Provider" %} | {{ block.super }}{% endblock %}
 
-    <form action="" method="post">
-        {% csrf_token %}
-        {% if plugin %}
-            <input type="hidden" name="plugin" value="{{ plugin.slug }}" />
-        {% endif %}
+{% block main %}
+<h3>Register Identity Provider</h3>
 
-        <hr>
-        <div class="help-block">
-        {% if error_url %}
-            <div class="alert alert-block alert-error">There was an error trying to retrieve and parse the metadata.</div>
-        {% endif %}
-        1. Use the metadata url retrieval method 
-        <a id="get_metadata_toggle" class="align-right" style="display:inline-block;">{% if not error_url %}[+]{% else %}[-]{% endif%}</a>
+<ul class="nav nav-tabs auth-toggle border-bottom">
+  <li {% if op == "url" %} class="active"{% endif %}>
+    <a href="#metadata-url" data-toggle="tab">Metadata URL</a>
+  </li>
+  <li {% if op == "xml" %} class="active"{% endif %}>
+    <a href="#xml" data-toggle="tab">XML</a>
+  </li>
+  <li {% if op == "idp" %} class="active"{% endif %}>
+    <a href="#idp-data" data-toggle="tab">IdP Data</a>
+  </li>
+</ul>
+
+<form action="" method="post" class="form-stacked">
+  {% csrf_token %}
+
+  {% if plugin %}
+      <input type="hidden" name="plugin" value="{{ plugin.slug }}" />
+  {% endif %}
+
+  <div class="tab-content">
+    <div class="tab-pane {% if op == "url" %}active{% endif %}" id="metadata-url">
+      <p>Provide a Metadata URL to retrieve the IdP details.</p>
+
+      {% if error_url %}
+        <div class="alert alert-block alert-error">
+          There was an error while requesting the metadata.
         </div>
-        <div id="get_metadata_section" {% if not error_url %} style="display:none;" {% endif %}>
-            <input class="textinput textInput form-control" id="idp_metadata_url" name="idp_metadata_url" type="url" value="{{ url }}" />
-            <fieldset class="align-right">
-              <div class="form-actions-samlidp">
-                <button type="submit" class="btn btn-primary" name="action_get_metadata">Get metadata</button>
-              </div>
-            </fieldset>
-        </div>
-        <hr>
-        <div class="help-block">
-        {% if error_xml %}
-            <div class="alert alert-block alert-error">There was an error trying to parse the XML of the metadata.</div>
-        {% endif %}
-        2. Paste the metadata XML
-        <a id="parse_metadata_toggle" class="align-right" style="display:inline-block;">{% if not error_xml %}[+]{% else %}[-]{% endif%}</a>
-        </div>
-        <div id="parse_metadata_section" {% if not error_xml %}style="display:none;" {% endif %}>
-            <textarea class="textarea form-control" cols="40" id="idp_metadata_xml" name="idp_metadata_xml" rows="10" value="{{ xml }}"></textarea>
-            <fieldset class="align-right">
-              <div class="form-actions-samlidp">
-                <button type="submit" class="btn btn-primary" name="action_parse_metadata">Parse metadata</button>
-              </div>
-            </fieldset>
-        </div>
+      {% endif %}
 
-        <hr>
-        <div class="help-block">3. Directly fill the IdP data form:</div>
-        
-        {% include "sentry/partial/form_base.html" %}
+      <label for="idp_metadata_url" label="control-label requiredField">
+        Metadata URL<span class="asteriskField">*</span>
+      </label>
+      <input
+        class="textinput textInput form-control"
+        id="idp_metadata_url"
+        name="idp_metadata_url"
+        type="url"
+        value="{{ url }}" />
 
-        <fieldset class="align-right">
-          <div class="form-actions-samlidp">
-            <button type="submit" class="btn btn-primary" name="action_save">Save</button>
-          </div>
-        </fieldset>
-    </form>
+      <fieldset class="form-actions">
+        <button
+          type="submit"
+          class="btn btn-primary"
+          name="action_get_metadata">{% trans "Get metadata" %}</button>
+      </fieldset>
+    </div>
 
+    <div class="tab-pane {% if op == "xml" %}active{% endif %}" id="xml">
+      <p>Provide the raw Metadata XML IdP details.</p>
+
+      {% if error_xml %}
+        <div class="alert alert-block alert-error">
+          There was an error while parsing the metadata XML.
+        </div>
+      {% endif %}
+
+      <label for="idp_metadata_url" label="control-label requiredField">
+        Metadata XML<span class="asteriskField">*</span>
+      </label>
+      <textarea
+        class="textarea form-control"
+        cols="40"
+        rows="10"
+        id="idp_metadata_xml"
+        name="idp_metadata_xml"
+        value="{{ xml }}"></textarea>
+
+      <fieldset class="form-actions">
+        <button
+          type="submit"
+          class="btn btn-primary"
+          name="action_parse_metadata">{% trans "Parse Metadata" %}</button>
+      </fieldset>
+    </div>
+
+    <div class="tab-pane {% if op == "idp" %}active{% endif %}" id="idp-data">
+      <p>
+        Provide your individual Identity Provider metadata fields.
+      </p>
+
+      {% include "sentry/partial/form_base.html" %}
+
+      <fieldset class="form-actions">
+        <button
+          type="submit"
+          class="btn btn-primary"
+          name="action_save">{% trans "Parse Metadata" %}</button>
+      </fieldset>
     </div>
   </div>
-
-<script>
-function changeToggleIcon(adad) {
-    if (a.text() == '[+]') {
-        a.text('[-]');
-    } else {
-        a.text('[+]');
-    }
-}
-
-$("#get_metadata_toggle").click(function(){
-    $("#get_metadata_section").toggle();
-    changeToggleIcon($(this));
-});
-
-$("#parse_metadata_toggle").click(function(){
-    $("#parse_metadata_section").toggle();
-    changeToggleIcon($(this));
-});
-</script>
+</form>
 
 {% endblock %}

--- a/sentry_auth_saml2/views.py
+++ b/sentry_auth_saml2/views.py
@@ -40,7 +40,10 @@ class SelectIdP(AuthView):
     def handle(self, request, helper):
         error_url = error_xml = False
         url = xml = ''
+        op = 'url'
+
         if 'action_save' in request.POST:
+            op = 'idp'
             form = SelectIdPForm(request.POST)
             if form.is_valid():
                 idp_data = SAML2Provider.extract_idp_data_from_form(form)
@@ -52,6 +55,7 @@ class SelectIdP(AuthView):
             form = SelectIdPForm()
             if 'action_get_metadata' in request.POST or 'action_parse_metadata' in request.POST:
                 if 'action_get_metadata' in request.POST:
+                    op = 'url'
                     url = request.POST['idp_metadata_url']
                     error_url = True
                     if url:
@@ -60,6 +64,7 @@ class SelectIdP(AuthView):
                         except:
                             data = None
                 else:
+                    op = 'xml'
                     xml = request.POST['idp_metadata_xml']
                     error_xml = True
                     if xml:
@@ -76,6 +81,7 @@ class SelectIdP(AuthView):
                         return helper.next_step()
 
         return self.respond('sentry_auth_saml2/select-idp.html', {
+            'op': op,
             'form': form,
             'error_url': error_url,
             'url': url,


### PR DESCRIPTION
Move each exclusive setup method into a tab item. Correctly focused the tab based on the operation being performed.

Visual difference

![image](https://user-images.githubusercontent.com/1421724/30299011-96489112-9702-11e7-9ac9-9d6c16b4e620.png)
↓
![image](https://user-images.githubusercontent.com/1421724/30299166-51db1bd4-9703-11e7-9166-1f33cc0f913a.png)


