### PR TITLE
Implement advanced OneLogin config

### DIFF
--- a/src/sentry_auth_saml2/onelogin/constants.py
+++ b/src/sentry_auth_saml2/onelogin/constants.py
@@ -2,4 +2,5 @@ from __future__ import absolute_import, print_function
 
 
 ONELOGIN_EMAIL = 'User.email'
-ONELOGIN_FIRSTNAME = 'User.FirstName'
+ONELOGIN_USERNAME = 'User.Username'
+ONELOGIN_DISPLAYNAME = 'User.FirstName'

--- a/src/sentry_auth_saml2/onelogin/constants.py
+++ b/src/sentry_auth_saml2/onelogin/constants.py
@@ -2,5 +2,4 @@ from __future__ import absolute_import, print_function
 
 
 ONELOGIN_EMAIL = 'User.email'
-ONELOGIN_USERNAME = 'User.Username'
 ONELOGIN_DISPLAYNAME = 'User.FirstName'

--- a/src/sentry_auth_saml2/onelogin/provider.py
+++ b/src/sentry_auth_saml2/onelogin/provider.py
@@ -6,7 +6,7 @@ from .views import (
     OneLoginSAML2ConfigureView, SelectIdP
 )
 
-from .constants import ONELOGIN_EMAIL, ONELOGIN_FIRSTNAME
+from .constants import ONELOGIN_EMAIL, ONELOGIN_USERNAME, ONELOGIN_DISPLAYNAME
 
 
 class OneLoginSAML2Provider(SAML2Provider):
@@ -26,6 +26,7 @@ class OneLoginSAML2Provider(SAML2Provider):
         if data:
             data['attribute_mapping'] = {
                 'attribute_mapping_email': ONELOGIN_EMAIL,
-                'attribute_mapping_firstname': ONELOGIN_FIRSTNAME
+                'attribute_mapping_username': ONELOGIN_USERNAME,
+                'attribute_mapping_displayname': ONELOGIN_DISPLAYNAME,
             }
         return data

--- a/src/sentry_auth_saml2/onelogin/provider.py
+++ b/src/sentry_auth_saml2/onelogin/provider.py
@@ -6,7 +6,7 @@ from .views import (
     OneLoginSAML2ConfigureView, SelectIdP
 )
 
-from .constants import ONELOGIN_EMAIL, ONELOGIN_USERNAME, ONELOGIN_DISPLAYNAME
+from .constants import ONELOGIN_EMAIL, ONELOGIN_DISPLAYNAME
 
 
 class OneLoginSAML2Provider(SAML2Provider):
@@ -26,7 +26,6 @@ class OneLoginSAML2Provider(SAML2Provider):
         if data:
             data['attribute_mapping'] = {
                 'attribute_mapping_email': ONELOGIN_EMAIL,
-                'attribute_mapping_username': ONELOGIN_USERNAME,
                 'attribute_mapping_displayname': ONELOGIN_DISPLAYNAME,
             }
         return data

--- a/src/sentry_auth_saml2/onelogin/templates/sentry_auth_onelogin/configure.html
+++ b/src/sentry_auth_saml2/onelogin/templates/sentry_auth_onelogin/configure.html
@@ -6,24 +6,45 @@
 <h3>OneLogin Settings</h3>
 
 <h4>OneLogin IdP Data</h4>
-{% if form.errors %}
+{% if saml_form.errors %}
     <div class="alert alert-block alert-error">{% trans "Please correct the errors below." %}</div>
 {% endif %}
 
-{{ form|as_crispy_errors }}
+{{ saml_form|as_crispy_errors }}
 
-{% for field in form %}
+{% for field in saml_form %}
+    {{ field|as_crispy_field }}
+{% endfor %}
+
+<h4>Options</h4>
+{% if options_form.errors %}
+    <div class="alert alert-block alert-error">{% trans "Please correct the errors below." %}</div>
+{% endif %}
+
+{{ options_form|as_crispy_errors }}
+
+{% for field in options_form %}
     {{ field|as_crispy_field }}
 {% endfor %}
 
 <h4>Attribute Mapping</h4>
-
-{% if form2.errors %}
+{% if attr_mapping_form.errors %}
     <div class="alert alert-block alert-error">{% trans "Please correct the errors below." %}</div>
 {% endif %}
 
-{{ form2|as_crispy_errors }}
+{{ attr_mapping_form|as_crispy_errors }}
 
-{% for field in form2 %}
+{% for field in attr_mapping_form %}
+    {{ field|as_crispy_field }}
+{% endfor %}
+
+<h4>Advanced Settings</h4>
+{% if advanced_form.errors %}
+    <div class="alert alert-block alert-error">{% trans "Please correct the errors below." %}</div>
+{% endif %}
+
+{{ advanced_form|as_crispy_errors }}
+
+{% for field in advanced_form %}
     {{ field|as_crispy_field }}
 {% endfor %}

--- a/src/sentry_auth_saml2/onelogin/views.py
+++ b/src/sentry_auth_saml2/onelogin/views.py
@@ -4,44 +4,18 @@ from django import forms
 from django.core.exceptions import ValidationError
 from django.core.urlresolvers import reverse
 from django.core.validators import URLValidator
+from django.utils.translation import ugettext_lazy as _
 
 from onelogin.saml2.idp_metadata_parser import OneLogin_Saml2_IdPMetadataParser
 
-from sentry.auth.view import AuthView, ConfigureView
-from sentry.auth.providers.saml2 import SAML2Provider
+from sentry.auth.view import AuthView
+from sentry.auth.providers.saml2 import (
+    SAML2Provider,
+    SAML2ConfigureView as BaseSAML2ConfigureView,
+    NAMEID_FORMAT_CHOICES,
+    AUTHNCONTEXT_CHOICES
+)
 from sentry.utils.http import absolute_uri
-
-
-class OneLoginSAML2ConfigureView(ConfigureView):
-    def dispatch(self, request, organization, auth_provider):
-        if request.POST:
-            data = request.POST
-            form = SAMLForm(data)
-            form2 = AttributeMappingForm(data)
-            if form.is_valid():
-                idp_data = SAML2Provider.extract_idp_data_from_form(form)
-                auth_provider.config['idp'] = idp_data
-                auth_provider.save()
-            if form2.is_valid():
-                attribute_mapping_data = SAML2Provider.extract_attribute_mapping_from_form(form2)
-                auth_provider.config['attribute_mapping'] = attribute_mapping_data
-                auth_provider.save()
-        else:
-            data = auth_provider.config['idp']
-            form = SAMLForm(data)
-
-            data2 = None
-            if 'attribute_mapping' in auth_provider.config:
-                data2 = auth_provider.config['attribute_mapping']
-            form2 = AttributeMappingForm(data2)
-
-        sp_metadata_url = absolute_uri(reverse('sentry-auth-organization-saml-metadata', args=[organization.slug]))
-
-        return self.render('sentry_auth_onelogin/configure.html', {
-            'sp_metadata_url': sp_metadata_url,
-            'form': form,
-            'form2': form2,
-        })
 
 
 class SAMLForm(forms.Form):
@@ -51,9 +25,70 @@ class SAMLForm(forms.Form):
     idp_x509cert = forms.CharField(label='OneLogin x509 public certificate', widget=forms.Textarea, help_text="X.509 Certificate")
 
 
-class AttributeMappingForm(forms.Form):
-    attribute_mapping_email = forms.CharField(label='Email')
-    attribute_mapping_firstname = forms.CharField(label='First Name', required=False)
+class AdvancedForm(forms.Form):
+    advanced_spentityid = forms.CharField(
+        label='SP EntityID',
+        required=False,
+        help_text=_('Service Provider EntityID, if not provided, the URL where '
+                    'Sentry publish the SP metadata will be used as its value')
+    )
+    advanced_nameidformat = forms.ChoiceField(
+        label='NameID Format',
+        required=False,
+        choices=NAMEID_FORMAT_CHOICES,
+        help_text=_('Specifies constraints on the name identifier to be used to '
+                    'represent the requested subject. Review OneLogin metadata '
+                    'to see the supported NameID formats')
+    )
+    advanced_requestedauthncontext = forms.MultipleChoiceField(
+        label='Requested Authn Context',
+        required=False,
+        choices=AUTHNCONTEXT_CHOICES,
+        help_text=_('AuthContext sent in the AuthNRequest. You can select none '
+                    '(any authn source will be accepted), one or multiple '
+                    'values')
+    )
+    advanced_sp_x509cert = forms.CharField(
+        label='SP X.509 Certificate',
+        widget=forms.Textarea,
+        required=False,
+        help_text=_('Public x509 certificate of the Service Provider')
+    )
+    advanced_sp_privatekey = forms.CharField(
+        label='SP Private Key',
+        widget=forms.Textarea,
+        required=False,
+        help_text=_('Private Key of the Service Provider')
+    )
+
+    def clean(self):
+        super(AdvancedForm, self).clean()
+
+        requires_sp_cert_data_due_enc = self.data.get('advanced_want_assertion_encrypted', False)
+        has_sp_cert_data = self.data.get('advanced_sp_x509cert', None) and self.data.get('advanced_sp_privatekey', None)
+
+        if requires_sp_cert_data_due_enc and not has_sp_cert_data:
+            self._errors["advanced_sp_x509cert"] = [_("Required in order to be provided to OneLogin to let it encrypt")]
+            self._errors["advanced_sp_privatekey"] = [_("Required in order to decrypt SAML data from OneLogin")]
+            del self.cleaned_data["advanced_sp_x509cert"]
+            del self.cleaned_data["advanced_sp_privatekey"]
+        return self.cleaned_data
+
+
+class OneLoginSAML2ConfigureView(BaseSAML2ConfigureView):
+    saml_form_cls = SAMLForm
+    advanced_form_cls = AdvancedForm
+
+    def display_configure_view(self, organization, saml_form, options_form, attr_mapping_form, advanced_form):
+        sp_metadata_url = absolute_uri(reverse('sentry-auth-organization-saml-metadata', args=[organization.slug]))
+
+        return self.render('sentry_auth_onelogin/configure.html', {
+            'sp_metadata_url': sp_metadata_url,
+            'saml_form': saml_form,
+            'options_form': options_form,
+            'attr_mapping_form': attr_mapping_form,
+            'advanced_form': advanced_form
+        })
 
 
 class SelectIdP(AuthView):


### PR DESCRIPTION
A cleaned up version of https://github.com/getsentry/sentry-auth-onelogin/pull/2

- Supports configuration for SLO
- Uses forms exposed in the sentry saml2 authentication module.

Requires https://github.com/getsentry/sentry/pull/6146

