### PR TITLE
ref: Handle downloading IdP xml with sentry.http

### DIFF
--- a/src/sentry_auth_saml2/forms.py
+++ b/src/sentry_auth_saml2/forms.py
@@ -5,6 +5,8 @@ from django.forms.util import ErrorList
 from django.utils.translation import ugettext_lazy as _
 from onelogin.saml2.idp_metadata_parser import OneLogin_Saml2_IdPMetadataParser
 
+from sentry.http import safe_urlopen
+
 
 def extract_idp_data_from_parsed_data(data):
     """
@@ -23,7 +25,8 @@ def extract_idp_data_from_parsed_data(data):
 
 def process_url(form):
     url = form.cleaned_data['metadata_url']
-    data = OneLogin_Saml2_IdPMetadataParser.parse_remote(url)
+    response = safe_urlopen(url)
+    data = OneLogin_Saml2_IdPMetadataParser.parse(response.content)
     return extract_idp_data_from_parsed_data(data)
 
 

--- a/src/sentry_auth_saml2/forms.py
+++ b/src/sentry_auth_saml2/forms.py
@@ -28,7 +28,9 @@ def process_url(form):
 
 
 def process_xml(form):
-    xml = form.cleaned_data['metadata_xml']
+    # cast unicode xml to byte string so lxml won't complain when trying to
+    # parse a xml document with a type declaration.
+    xml = form.cleaned_data['metadata_xml'].encode('utf8')
     data = OneLogin_Saml2_IdPMetadataParser.parse(xml)
     return extract_idp_data_from_parsed_data(data)
 


### PR DESCRIPTION
Keeping http fetches on the same codepath, helping to avoid security concerns.