### PR TITLE
fix template paths in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,7 @@
 include setup.py package.json webpack.config.js README.rst MANIFEST.in LICENSE AUTHORS
-recursive-include sentry_auth_saml2/templates *
+recursive-include sentry_auth_saml2/auth0/templates/sentry_auth_auth0 *
+recursive-include sentry_auth_saml2/generic/templates/sentry_auth_saml2 *
+recursive-include sentry_auth_saml2/okta/templates/sentry_auth_okta *
+recursive-include sentry_auth_saml2/onelogin/templates/sentry_auth_onelogin *
+recursive-include sentry_auth_saml2/rippling/templates/sentry_auth_rippling *
 global-exclude *~

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,7 @@
 include setup.py package.json webpack.config.js README.rst MANIFEST.in LICENSE AUTHORS
-recursive-include sentry_auth_saml2/auth0/templates/sentry_auth_auth0 *
-recursive-include sentry_auth_saml2/generic/templates/sentry_auth_saml2 *
-recursive-include sentry_auth_saml2/okta/templates/sentry_auth_okta *
-recursive-include sentry_auth_saml2/onelogin/templates/sentry_auth_onelogin *
-recursive-include sentry_auth_saml2/rippling/templates/sentry_auth_rippling *
+recursive-include src/sentry_auth_saml2/auth0/templates *
+recursive-include src/sentry_auth_saml2/generic/templates *
+recursive-include src/sentry_auth_saml2/okta/templates *
+recursive-include src/sentry_auth_saml2/onelogin/templates *
+recursive-include src/sentry_auth_saml2/rippling/templates *
 global-exclude *~


### PR DESCRIPTION
Been investigating SAML this morning, installing via `RUN pip install https://github...` in our on-premise Docker image. After finding the feature flag that needed enabling (could do with a mention in the README) clicking through to configure a provider threw this error:

```
TemplateDoesNotExist: sentry_auth_saml2/select-idp.html
12:28:07 [ERROR] django.request: Internal Server Error: /organizations/sentry/auth/ (status_code=500 request=<WSGIRequest: POST u'/organizations/sentry/auth/'>)
```

This PR updates MANIFEST.in to include those missing template files. Pretty unfamiliar with the python ecosystem - so not sure if there is a better/cleaner way to handle these.