### PR TITLE
Install templates as package data files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,2 @@
 include setup.py package.json webpack.config.js README.rst MANIFEST.in LICENSE AUTHORS
-recursive-include sentry_auth_saml2/templates *
 global-exclude *~

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
     license='Apache 2.0',
     package_dir={'': 'src'},
     packages=find_packages('src', exclude=['tests']),
+    package_data={'': ['templates/*/*.html']},
     zip_safe=False,
     install_requires=install_requires,
     tests_require=tests_require,


### PR DESCRIPTION
The current MANIFEST.in is faulty and does not install the template needed for the package to work.

This patch fixes the current template paths, but does not provide forwards compatibility if someone adds a template that is not in `templates/<subdirectory>/<file.html>` formatted path; these could be further supported by globbing all template files and generating them with a dict comprehension into `package_data` in `setup.py`.