### PR TITLE
ref(build): Improved template inclusion

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,8 @@
 include setup.py package.json webpack.config.js README.rst MANIFEST.in LICENSE AUTHORS
 recursive-include src/sentry_auth_saml2 *.html
+recursive-include src/sentry_auth_saml2 *.js
+recursive-include src/sentry_auth_saml2 *.jsx
+recursive-include src/sentry_auth_saml2 *.css
+recursive-include src/sentry_auth_saml2 *.js.gz
+recursive-include src/sentry_auth_saml2 *.js.map
 global-exclude *~

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include setup.py package.json webpack.config.js README.rst MANIFEST.in LICENSE AUTHORS
+recursive-include src/sentry_auth_saml2 *.html
 global-exclude *~

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
     license='Apache 2.0',
     package_dir={'': 'src'},
     packages=find_packages('src', exclude=['tests']),
-    package_data={'': ['templates/*/*.html']},
     zip_safe=False,
     install_requires=install_requires,
     tests_require=tests_require,


### PR DESCRIPTION
Improved fix for both #20 and #23.

Brings this inline with the way we import non-python files [in plugins](https://github.com/getsentry/sentry-plugins/blob/1cfb851b8190d7c6245bedb212a0083148cce0a8/MANIFEST.in#L2-L7).