### PR TITLE
fix: Bump saml2 library to 1.40 for CVE-2017-11427

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 
 install_requires = [
-    'python3-saml>=1.2.3'
+    'python3-saml>=1.4.0'
 ]
 
 tests_require = [


### PR DESCRIPTION
Fixes: https://github.com/getsentry/sentry/issues/7382

Verified things are still working in dev.