### PR TITLE
py3(django): fix Django 1.9 deprecation warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,8 @@
 .PHONY: clean develop install-tests lint publish test
 
 develop:
-	pip install "pip>=7"
-	pip install -e .
-	make install-tests
-
-install-tests:
+	pip install "pip==19.2.3"
+	SENTRY_LIGHT_BUILD=1 pip install --no-use-pep517 -e ../sentry
 	pip install .[tests]
 
 lint:

--- a/conftest.py
+++ b/conftest.py
@@ -5,10 +5,6 @@ import os.path
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__)))
 
-# Run tests against sqlite for simplicity
-import os
-os.environ.setdefault('DB', 'sqlite')
-
 pytest_plugins = [
     'sentry.utils.pytest'
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [wheel]
 universal = 1
 
-[pytest]
+[tool:pytest]
 python_files = test*.py
 addopts = --tb=native -p no:doctest
 norecursedirs = bin dist docs htmlcov script hooks node_modules .* {args}

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,10 @@ install_requires = [
 ]
 
 tests_require = [
-    'flake8>=2.0,<2.1',
+    "exam>=0.5.1",
+    'pytest==4.6.5',
+    "pytest-html==1.22.0",
+    'sentry-flake8==0.1.1',
 ]
 
 setup(

--- a/src/sentry_auth_saml2/forms.py
+++ b/src/sentry_auth_saml2/forms.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from django import forms
-from django.forms.util import ErrorList
+from django.forms.utils import ErrorList
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 from onelogin.saml2.idp_metadata_parser import OneLogin_Saml2_IdPMetadataParser


### PR DESCRIPTION
Related to https://github.com/getsentry/sentry/pull/15025.

Also updated a bit of the make/test stuff so I could actually run tests, haha.

EDIT: Oh, well there are actually no tests. Anyways, made those changes, might as well keep them.