### PR TITLE
py3(django): keep backwards compat with Django 1.6 for Sentry 9.1.2

### DIFF
--- a/src/sentry_auth_saml2/forms.py
+++ b/src/sentry_auth_saml2/forms.py
@@ -1,10 +1,15 @@
 from __future__ import absolute_import
 
+import django
 from django import forms
-from django.forms.utils import ErrorList
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 from onelogin.saml2.idp_metadata_parser import OneLogin_Saml2_IdPMetadataParser
+
+if django.VERSION >= (1, 8):
+    from django.forms.utils import ErrorList
+else:
+    from django.forms.util import ErrorList
 
 from sentry.http import safe_urlopen
 


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry-auth-saml2/pull/42, which wasn't done in a Django 1.6 backwards-compatible manner, the version that Sentry 9.1.2 uses. Fixes https://github.com/getsentry/sentry-auth-saml2/issues/43, https://github.com/getsentry/sentry-auth-saml2/issues/44.
