### PR TITLE
py3(django): use AppConfig to defer model imports via sentry.auth

### DIFF
--- a/src/sentry_auth_saml2/auth0/__init__.py
+++ b/src/sentry_auth_saml2/auth0/__init__.py
@@ -1,7 +1,1 @@
 from __future__ import absolute_import
-
-from sentry.auth import register
-
-from .provider import Auth0SAML2Provider
-
-register('auth0', Auth0SAML2Provider)

--- a/src/sentry_auth_saml2/auth0/__init__.py
+++ b/src/sentry_auth_saml2/auth0/__init__.py
@@ -1,3 +1,16 @@
 from __future__ import absolute_import
 
-default_app_config = "sentry_auth_saml2.auth0.apps.Config"
+import django
+
+if django.VERSION[:2] >= (1, 8):
+    # Django 1.9 specifically requires that models not be imported before setup,
+    # which sentry.auth does, so we need to use AppConfig here.
+    # Also works on 1.8.
+    default_app_config = "sentry_auth_saml2.auth0.apps.Config"
+else:
+    # Provide backwards compatibility.
+    from sentry.auth import register
+
+    from .provider import Auth0SAML2Provider
+
+    register('auth0', Auth0SAML2Provider)

--- a/src/sentry_auth_saml2/auth0/__init__.py
+++ b/src/sentry_auth_saml2/auth0/__init__.py
@@ -1,1 +1,3 @@
 from __future__ import absolute_import
+
+default_app_config = "sentry_auth_saml2.auth0.apps.Config"

--- a/src/sentry_auth_saml2/auth0/apps.py
+++ b/src/sentry_auth_saml2/auth0/apps.py
@@ -1,0 +1,14 @@
+from __future__ import absolute_import
+
+from django.apps import AppConfig
+
+
+class Config(AppConfig):
+    name = "sentry_auth_saml2.auth0"
+
+    def ready(self):
+        from sentry.auth import register
+
+        from .provider import Auth0SAML2Provider
+
+        register('auth0', Auth0SAML2Provider)

--- a/src/sentry_auth_saml2/generic/__init__.py
+++ b/src/sentry_auth_saml2/generic/__init__.py
@@ -1,3 +1,16 @@
 from __future__ import absolute_import
 
-default_app_config = "sentry_auth_saml2.generic.apps.Config"
+import django
+
+if django.VERSION[:2] >= (1, 8):
+    # Django 1.9 specifically requires that models not be imported before setup,
+    # which sentry.auth does, so we need to use AppConfig here.
+    # Also works on 1.8.
+    default_app_config = "sentry_auth_saml2.generic.apps.Config"
+else:
+    # Provide backwards compatibility.
+    from sentry.auth import register
+
+    from .provider import GenericSAML2Provider
+
+    register('saml2', GenericSAML2Provider)

--- a/src/sentry_auth_saml2/generic/__init__.py
+++ b/src/sentry_auth_saml2/generic/__init__.py
@@ -1,7 +1,1 @@
 from __future__ import absolute_import
-
-from sentry.auth import register
-
-from .provider import GenericSAML2Provider
-
-register('saml2', GenericSAML2Provider)

--- a/src/sentry_auth_saml2/generic/__init__.py
+++ b/src/sentry_auth_saml2/generic/__init__.py
@@ -1,1 +1,3 @@
 from __future__ import absolute_import
+
+default_app_config = "sentry_auth_saml2.generic.apps.Config"

--- a/src/sentry_auth_saml2/generic/apps.py
+++ b/src/sentry_auth_saml2/generic/apps.py
@@ -1,0 +1,14 @@
+from __future__ import absolute_import
+
+from django.apps import AppConfig
+
+
+class Config(AppConfig):
+    name = "sentry_auth_saml2.generic"
+
+    def ready(self):
+        from sentry.auth import register
+
+        from .provider import GenericSAML2Provider
+
+        register('saml2', GenericSAML2Provider)

--- a/src/sentry_auth_saml2/okta/__init__.py
+++ b/src/sentry_auth_saml2/okta/__init__.py
@@ -1,1 +1,3 @@
 from __future__ import absolute_import
+
+default_app_config = "sentry_auth_saml2.okta.apps.Config"

--- a/src/sentry_auth_saml2/okta/__init__.py
+++ b/src/sentry_auth_saml2/okta/__init__.py
@@ -1,3 +1,16 @@
 from __future__ import absolute_import
 
-default_app_config = "sentry_auth_saml2.okta.apps.Config"
+import django
+
+if django.VERSION[:2] >= (1, 8):
+    # Django 1.9 specifically requires that models not be imported before setup,
+    # which sentry.auth does, so we need to use AppConfig here.
+    # Also works on 1.8.
+    default_app_config = "sentry_auth_saml2.okta.apps.Config"
+else:
+    # Provide backwards compatibility.
+    from sentry.auth import register
+
+    from .provider import OktaSAML2Provider
+
+    register('okta', OktaSAML2Provider)

--- a/src/sentry_auth_saml2/okta/__init__.py
+++ b/src/sentry_auth_saml2/okta/__init__.py
@@ -1,7 +1,1 @@
 from __future__ import absolute_import
-
-from sentry.auth import register
-
-from .provider import OktaSAML2Provider
-
-register('okta', OktaSAML2Provider)

--- a/src/sentry_auth_saml2/okta/apps.py
+++ b/src/sentry_auth_saml2/okta/apps.py
@@ -1,0 +1,14 @@
+from __future__ import absolute_import
+
+from django.apps import AppConfig
+
+
+class Config(AppConfig):
+    name = "sentry_auth_saml2.okta"
+
+    def ready(self):
+        from sentry.auth import register
+
+        from .provider import OktaSAML2Provider
+
+        register('okta', OktaSAML2Provider)

--- a/src/sentry_auth_saml2/onelogin/__init__.py
+++ b/src/sentry_auth_saml2/onelogin/__init__.py
@@ -1,3 +1,16 @@
 from __future__ import absolute_import
 
-default_app_config = "sentry_auth_saml2.onelogin.apps.Config"
+import django
+
+if django.VERSION[:2] >= (1, 8):
+    # Django 1.9 specifically requires that models not be imported before setup,
+    # which sentry.auth does, so we need to use AppConfig here.
+    # Also works on 1.8.
+    default_app_config = "sentry_auth_saml2.onelogin.apps.Config"
+else:
+    # Provide backwards compatibility.
+    from sentry.auth import register
+
+    from .provider import OneLoginSAML2Provider
+
+    register('onelogin', OneLoginSAML2Provider)

--- a/src/sentry_auth_saml2/onelogin/__init__.py
+++ b/src/sentry_auth_saml2/onelogin/__init__.py
@@ -1,1 +1,3 @@
 from __future__ import absolute_import
+
+default_app_config = "sentry_auth_saml2.onelogin.apps.Config"

--- a/src/sentry_auth_saml2/onelogin/__init__.py
+++ b/src/sentry_auth_saml2/onelogin/__init__.py
@@ -1,7 +1,1 @@
 from __future__ import absolute_import
-
-from sentry.auth import register
-
-from .provider import OneLoginSAML2Provider
-
-register('onelogin', OneLoginSAML2Provider)

--- a/src/sentry_auth_saml2/onelogin/apps.py
+++ b/src/sentry_auth_saml2/onelogin/apps.py
@@ -1,0 +1,14 @@
+from __future__ import absolute_import
+
+from django.apps import AppConfig
+
+
+class Config(AppConfig):
+    name = "sentry_auth_saml2.onelogin"
+
+    def ready(self):
+        from sentry.auth import register
+
+        from .provider import OneLoginSAML2Provider
+
+        register('onelogin', OneLoginSAML2Provider)

--- a/src/sentry_auth_saml2/rippling/__init__.py
+++ b/src/sentry_auth_saml2/rippling/__init__.py
@@ -1,3 +1,16 @@
 from __future__ import absolute_import
 
-default_app_config = "sentry_auth_saml2.rippling.apps.Config"
+import django
+
+if django.VERSION[:2] >= (1, 8):
+    # Django 1.9 specifically requires that models not be imported before setup,
+    # which sentry.auth does, so we need to use AppConfig here.
+    # Also works on 1.8.
+    default_app_config = "sentry_auth_saml2.rippling.apps.Config"
+else:
+    # Provide backwards compatibility.
+    from sentry.auth import register
+
+    from .provider import RipplingSAML2Provider
+
+    register('rippling', RipplingSAML2Provider)

--- a/src/sentry_auth_saml2/rippling/__init__.py
+++ b/src/sentry_auth_saml2/rippling/__init__.py
@@ -1,7 +1,1 @@
 from __future__ import absolute_import
-
-from sentry.auth import register
-
-from .provider import RipplingSAML2Provider
-
-register('rippling', RipplingSAML2Provider)

--- a/src/sentry_auth_saml2/rippling/__init__.py
+++ b/src/sentry_auth_saml2/rippling/__init__.py
@@ -1,1 +1,3 @@
 from __future__ import absolute_import
+
+default_app_config = "sentry_auth_saml2.rippling.apps.Config"

--- a/src/sentry_auth_saml2/rippling/apps.py
+++ b/src/sentry_auth_saml2/rippling/apps.py
@@ -1,0 +1,14 @@
+from __future__ import absolute_import
+
+from django.apps import AppConfig
+
+
+class Config(AppConfig):
+    name = "sentry_auth_saml2.rippling"
+
+    def ready(self):
+        from sentry.auth import register
+
+        from .provider import RipplingSAML2Provider
+
+        register('rippling', RipplingSAML2Provider)


### PR DESCRIPTION
[During working on making getsentry Django 1.9 compatible](https://github.com/getsentry/getsentry/pull/3294), I found out that `getsentry upgrade` ends up dynamically appending plugin stuff to `INSTALLED_APPS`, and it turns out that `sentry-auth-saml2` ends up implicitly importing models via `sentry.auth`. So it needs to be AppConfig'd.

Unfortunately, this is gonna break Sentry 9.1.2 because AppConfig isn't a thing in Django 1.6, I think. We could either merge this into master and edit the README to install the sha before it, or keep it on this branch and point getsentry to the last sha in here.

Oh yeah, I believe we have a bot that automatically bumps this in getsentry, so the latter approach might be problematic. The easiest way out might be to merge this into master.
